### PR TITLE
fix broken link to github project

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ description = "Easily collect telemetry like metrics and distributed traces from
 description = "Vendor-neutral APIs and instrumentation for distributed tracing"
 
 [[menu.social]]
-url = "https://github.com/open-telemetry/open-telemetry"
+url = "https://github.com/open-telemetry/"
 name = "GitHub"
 identifier = "github"
 


### PR DESCRIPTION
Maybe there is a better place to refer to, then please adjust.
For now some generic place for the link to not be broken anymore.